### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v2.3.1
+        uses: actions/checkout@v3.0.2
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@v2.1.0
+      - uses: pnpm/action-setup@v2.2.2
         with:
           version: 7.1.3
 
@@ -17,7 +17,7 @@ jobs:
         run: |
           echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v3.0.8
         name: Setup pnpm cache
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
@@ -37,7 +37,7 @@ jobs:
       - run: cp -rf images/* dist/images
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+        uses: JamesIves/github-pages-deploy-action@v4.4.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[pnpm/action-setup](https://github.com/pnpm/action-setup)** published a new release [v2.2.2](https://github.com/pnpm/action-setup/releases/tag/v2.2.2) on 2022-05-28T14:27:55Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release [v3.0.2](https://github.com/actions/checkout/releases/tag/v3.0.2) on 2022-04-21T14:56:58Z
* **[JamesIves/github-pages-deploy-action](https://github.com/JamesIves/github-pages-deploy-action)** published a new release [v4.4.0](https://github.com/JamesIves/github-pages-deploy-action/releases/tag/v4.4.0) on 2022-07-21T11:22:28Z
* **[actions/cache](https://github.com/actions/cache)** published a new release [v3.0.8](https://github.com/actions/cache/releases/tag/v3.0.8) on 2022-08-22T06:49:51Z
