### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v2.3.1
+        uses: actions/checkout@v2.5.0
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@v2.1.0
+      - uses: pnpm/action-setup@v2.2.4
         with:
           version: 7.1.3
 
@@ -17,7 +17,7 @@ jobs:
         run: |
           echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v3.0.11
         name: Setup pnpm cache
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
@@ -37,7 +37,7 @@ jobs:
       - run: cp -rf images/* dist/images
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages

--- a/.github/workflows/update_versions.yml
+++ b/.github/workflows/update_versions.yml
@@ -19,7 +19,7 @@ jobs:
           token: ${{ secrets.WORKFLOW_SECRET }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.5.6
+        uses: saadmk11/github-actions-version-updater@v0.7.1
         with:
           # Optional, This will be used to configure git
           # defaults to `github-actions[bot]` if not provided


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release [v2.5.0](https://github.com/actions/checkout/releases/tag/v2.5.0) on 2022-10-13T15:51:55Z
* **[JamesIves/github-pages-deploy-action](https://github.com/JamesIves/github-pages-deploy-action)** published a new release [v4.4.1](https://github.com/JamesIves/github-pages-deploy-action/releases/tag/v4.4.1) on 2022-10-13T03:31:44Z
* **[actions/cache](https://github.com/actions/cache)** published a new release [v3.0.11](https://github.com/actions/cache/releases/tag/v3.0.11) on 2022-10-13T11:18:20Z
* **[pnpm/action-setup](https://github.com/pnpm/action-setup)** published a new release [v2.2.4](https://github.com/pnpm/action-setup/releases/tag/v2.2.4) on 2022-10-15T18:14:46Z
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release [v0.7.1](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.7.1) on 2022-10-29T16:38:42Z
